### PR TITLE
Fix bug where $alwaysApply was ignored in async mutations

### DIFF
--- a/src/run/mutation.test.ts
+++ b/src/run/mutation.test.ts
@@ -777,3 +777,22 @@ test('should run mutation object asynchronously', async () => {
 
   assert.deepEqual(ret, expected)
 })
+
+test('should run mutation object on undefined asynchronously when always is true', async () => {
+  const value = undefined
+  const pipeline: PreppedPipeline = [
+    {
+      type: 'mutation',
+      pipelines: [
+        ['key', '>id'],
+        ['name', '>title'],
+      ],
+      always: true,
+    },
+  ]
+  const expected = { id: undefined, title: undefined }
+
+  const ret = await runPipelineAsync(value, pipeline, state)
+
+  assert.deepEqual(ret, expected)
+})

--- a/src/run/mutation.ts
+++ b/src/run/mutation.ts
@@ -53,11 +53,11 @@ export default function runMutationStep(
  */
 export async function runMutationStepAsync(
   value: unknown,
-  { pipelines, flip }: MutationStep,
+  { pipelines, flip, always }: MutationStep,
   state: State,
 ) {
-  // Don't mutate a non-value
-  if (isNonvalue(value, state.nonvalues)) {
+  // Don't mutate a non-value, unless `always` is true
+  if (!always && isNonvalue(value, state.nonvalues)) {
     return undefined
   }
 

--- a/src/tests/path.test.ts
+++ b/src/tests/path.test.ts
@@ -787,6 +787,22 @@ test('should run mutation object on non-value when $alwaysApply is true', () => 
   assert.deepEqual(ret, expected)
 })
 
+test('should run mutation object on undefined asynchronously when $alwaysApply is true', async () => {
+  const def = [
+    'items',
+    {
+      $alwaysApply: true,
+      attributes: { $alwaysApply: true, title: 'content.heading' },
+    },
+  ]
+  const data = { items: undefined }
+  const expected = { attributes: { title: undefined } }
+
+  const ret = await mapTransformAsync(def)(data)
+
+  assert.deepEqual(ret, expected)
+})
+
 test('should map with root operation', () => {
   const def = [
     'content',


### PR DESCRIPTION
`runMutationStepAsync()` never destructured `always` off the mutation step, so a mutation object with `$alwaysApply: true` was skipped when the pipeline value was a non-value — while the sync runner applied it.

```js
const def = { $alwaysApply: true, name: { $value: 'N' } }

mapTransform(def)(undefined)       // { name: 'N' }
await mapTransformAsync(def)(undefined) // undefined  <- should be { name: 'N' }
```

Added a unit test in `run/mutation.test.ts` and an integration test in `tests/path.test.ts`, both mirroring the existing sync tests. Both fail before the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)