### PR TITLE
Fix bug where $alt ignored nonvalues when getting a default in reverse

### DIFF
--- a/src/run/alt.test.ts
+++ b/src/run/alt.test.ts
@@ -311,6 +311,26 @@ test('should not get a default value from the last pipeline', () => {
   assert.deepEqual(ret, expected)
 })
 
+test('should skip default value that is a nonvalue', () => {
+  const value = undefined
+  const pipeline: PreppedPipeline = [
+    {
+      type: 'alt',
+      pipelines: [
+        ['name'],
+        [{ type: 'value', value: 'Default name' }],
+        [{ type: 'value', value: '' }],
+      ],
+    },
+  ]
+  const stateRevWithNonvalues = { rev: true, nonvalues: [undefined, ''] }
+  const expected = { name: 'Default name' }
+
+  const ret = runPipeline(value, pipeline, stateRevWithNonvalues)
+
+  assert.deepEqual(ret, expected)
+})
+
 test('should skip pipelines with wrong direction when getting default value', () => {
   const value = undefined
   const pipeline: PreppedPipeline = [

--- a/src/run/alt.ts
+++ b/src/run/alt.ts
@@ -86,7 +86,10 @@ function* getDefaultValue(
     const value = yield isAsync
       ? runPipelineAsync(undefined, pipeline, state)
       : runPipeline(undefined, pipeline, state)
-    if (!isUntouchedValue(undefined, value, pipeline) && !isNonvalue(value)) {
+    if (
+      !isUntouchedValue(undefined, value, pipeline) &&
+      !isNonvalue(value, state.nonvalues)
+    ) {
       return value
     }
   }


### PR DESCRIPTION
When `$alt` picks a default value in reverse, `getDefaultValue()` called `isNonvalue(value)` without passing `state.nonvalues`, so it fell back to the built-in `[undefined]`. A candidate default that the caller had declared a non-value — an empty string, `null`, `0` — was accepted instead of being skipped in favour of the next pipeline.

```js
const options = { nonvalues: [undefined, ''] }
const def = { name: [{ $alt: ['name', { $value: 'Default name' }, { $value: '' }] }] }

mapTransform(def, options)(undefined, { rev: true })
// before: { name: '' }
// after:  { name: 'Default name' }
```

Everywhere else in `run/alt.ts` already passes `state.nonvalues`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)