### PR TITLE
Unescape `**undefined**` in $nonvalues and $undefined

### DIFF
--- a/README.md
+++ b/README.md
@@ -395,6 +395,25 @@ This will essentially make MapTransform treat `null` the same way as
 You could in principle include any primitive value in `nonvalues` and it will be
 treated as `undefined`, e.g. an empty string or the number `0`.
 
+You may also set `$nonvalues` on an operation or mutation object, to use another
+set of non-values for that operation and any pipelines within it. This overrides
+the `nonvalues` option for that part of the definition. `$undefined` is an alias
+of `$nonvalues`, and when both are set, `$nonvalues` is used. As a definition
+may be written in JSON, where `undefined` cannot be expressed, the value
+`'**undefined**'` is treated as `undefined` in these lists:
+
+```javascript
+const def = {
+  // Treat an empty string as `undefined` when picking a default here
+  name: [
+    {
+      $alt: ['data.name', { $value: 'Anonymous' }],
+      $nonvalues: ['**undefined**', ''],
+    },
+  ],
+}
+```
+
 A mutation object will be skipped in its entirety when it encounters a non-value
 in the pipeline. This is not always wanted, e.g. when the mutation object has
 defaults that we want to set in the mutation object. In these cases, you may set

--- a/src/prep/alt.test.ts
+++ b/src/prep/alt.test.ts
@@ -51,6 +51,42 @@ test('should pass on $undefined as nonvalues', () => {
   assert.deepEqual(ret, expected)
 })
 
+test('should unescape **undefined** in $nonvalues', () => {
+  const def = {
+    $alt: [['title'], 'props.name'],
+    $nonvalues: ['**undefined**', ''],
+  }
+  const expected = [
+    {
+      type: 'alt' as const,
+      nonvalues: [undefined, ''],
+      pipelines: [['title'], ['props', 'name']],
+    },
+  ]
+
+  const ret = preparePipeline(def, options)
+
+  assert.deepEqual(ret, expected)
+})
+
+test('should unescape **undefined** in $undefined', () => {
+  const def = {
+    $alt: [['title'], 'props.name'],
+    $undefined: ['**undefined**', ''],
+  }
+  const expected = [
+    {
+      type: 'alt' as const,
+      nonvalues: [undefined, ''],
+      pipelines: [['title'], ['props', 'name']],
+    },
+  ]
+
+  const ret = preparePipeline(def, options)
+
+  assert.deepEqual(ret, expected)
+})
+
 test('should pass on $direction as dir', () => {
   const def = { $alt: [['title'], 'props.name'], $direction: 'rev' }
   const expected = [

--- a/src/prep/index.ts
+++ b/src/prep/index.ts
@@ -10,6 +10,7 @@ import prepareTransformStep from './transform.js'
 import prepareValueStep from './value.js'
 import modifyOperation from './modifyOperation.js'
 import { isNotNullOrUndefined } from '../utils/is.js'
+import { unescapeValue } from '../utils/escape.js'
 import type { PreppedPipeline, StepProps, OperationStep } from '../run/index.js'
 import type {
   Path,
@@ -111,11 +112,12 @@ function extractStepProps(
 ): [StepProps | undefined, MutationObject | OperationObject] {
   const it = $iterate === true
   const dir = getDir($direction, options)
-  const nonvalues = Array.isArray($nonvalues)
+  const rawNonvalues = Array.isArray($nonvalues)
     ? $nonvalues
     : Array.isArray($undefined)
       ? $undefined
       : undefined
+  const nonvalues = rawNonvalues?.map(unescapeValue)
 
   // Set $iterate back if it is not a boolean – as this is then a $iterate
   // operation

--- a/src/tests/default.test.ts
+++ b/src/tests/default.test.ts
@@ -671,3 +671,37 @@ test('should apply default in iterated deep structure', () => {
 
   assert.deepEqual(ret, expected)
 })
+
+test('should treat **undefined** in $nonvalues as undefined', () => {
+  const def = {
+    title: [
+      {
+        $alt: ['content.heading', { $value: 'Default heading' }],
+        $nonvalues: ['**undefined**'],
+      },
+    ],
+  }
+  const data = { content: {} }
+  const expected = { title: 'Default heading' }
+
+  const ret = mapTransformSync(def)(data)
+
+  assert.deepEqual(ret, expected)
+})
+
+test('should treat **undefined** in $undefined as undefined', () => {
+  const def = {
+    title: [
+      {
+        $alt: ['content.heading', { $value: 'Default heading' }],
+        $undefined: ['**undefined**'],
+      },
+    ],
+  }
+  const data = { content: {} }
+  const expected = { title: 'Default heading' }
+
+  const ret = mapTransformSync(def)(data)
+
+  assert.deepEqual(ret, expected)
+})


### PR DESCRIPTION
The `$nonvalues` and `$undefined` step props were passed through to the prepped step as-is, so the JSON escape hatch for `undefined` didn't work. A definition written in JSON had no way to declare `undefined` a non-value for an operation — the legacy API unescapes these (`setNoneValuesOnOptions()` in `definitionHelpers.ts`).

```js
const def = {
  title: [{ $alt: ['content.heading', { $value: 'Default heading' }], $nonvalues: ['**undefined**'] }],
}

mapTransform(def)({ content: {} })
// before: { title: undefined }   <- '**undefined**' was the non-value, so undefined was a value
// after:  { title: 'Default heading' }
```

Also documents `$nonvalues`/`$undefined` in README — they weren't mentioned at all, only the `nonvalues` option.

🤖 Generated with [Claude Code](https://claude.com/claude-code)