### PR TITLE
Clean up dead type, misnamed function and missing $fixed docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1829,6 +1829,10 @@ except that the value set with `fixed` will be included even when
 `state.noDefaults` is `true`. Use `value` for default values, and `fixed` for
 values that should be set no matter what.
 
+Like the `value` transformer, `fixed` has its own short-hand operation object
+notation, so `{ $transform: 'fixed', value: 'customer' }` may be written
+`{ $fixed: 'customer' }`.
+
 #### `flatten` transformer
 
 Will flatten an array in the pipeline. The default is to flatten one layer deep,

--- a/src/prep/iterate.ts
+++ b/src/prep/iterate.ts
@@ -2,7 +2,7 @@ import preparePipeline, { Options } from './index.js'
 import type { IterateStep } from '../run/iterate.js'
 import type { IterateOperation } from '../typesNext.js'
 
-export default function prepareArrayStep(
+export default function prepareIterateStep(
   { $iterate: pipeline }: IterateOperation,
   options: Options,
 ): IterateStep | undefined {

--- a/src/run/index.ts
+++ b/src/run/index.ts
@@ -83,14 +83,6 @@ export type OperationStep =
 export type PreppedStep = Path | OperationStep
 export type PreppedPipeline = PreppedStep[]
 
-export interface PreppedOptions {
-  pipelines: Map<string | symbol, PreppedPipeline>
-  nonvalues?: unknown[]
-  modifyOperationObject: (
-    operation: Record<string, unknown>,
-  ) => Record<string, unknown>
-}
-
 const isOperationObject = (step: PreppedStep): step is OperationStep =>
   isObject(step) && typeof step.type === 'string'
 


### PR DESCRIPTION
Three small things found while comparing `next` with the legacy API:

- **`PreppedOptions` in `run/index.ts` was dead.** Nothing referenced it — `run/` gets what it needs off `State`. Removed.
- **`prep/iterate.ts` exported its step preparer as `prepareArrayStep`**, copy-pasted from `prep/array.ts`, while returning an `IterateStep`. `prep/index.ts` already imports it as `prepareIterateStep`, so only the declaration changed.
- **`$fixed` was undocumented.** The `value` transformer section explains its `$value` short-hand; the `fixed` section now does the same for `$fixed`.

No behaviour change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)