### PR TITLE
Add prepareOptions() for next, and stop re-entrant preparation

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,6 +197,14 @@ it won't happen again on the next call. `prepareOptions` is idempotent, so
 passing already prepared options to `mapTransform` -- or calling
 `prepareOptions` on them again -- costs nothing.
 
+The upcoming v2 functions have their own `prepareOptions`, which works the same
+way and is just as optional -- options you haven't prepared are prepared for
+you, you just don't get to share the result with the next call. One difference
+is worth knowing about: a pipeline is prepared with the transformers baked into
+it, and the synchronous and the asynchronous version use different transformers,
+so they never share prepared pipelines with each other. Preparing the same
+options for both is fine, each gets its own.
+
 > [!NOTE] We are preparing for an upcoming 2.0 version, which will include
 > breaking changes.
 >

--- a/src/mapTransform.ts
+++ b/src/mapTransform.ts
@@ -4,10 +4,14 @@ import {
   sync as syncTransformers,
   async as asyncTransformers,
 } from './transformers/index.js'
+import prepareOptions, {
+  prepareOptionsWithBookKeeping,
+  withBookKeeping,
+} from './prepareOptions.js'
 import State from './state.js'
-import type { Transformer, AsyncTransformer } from './typesNext.js'
+import type { Variant, VariantBookKeeping } from './prepareOptions.js'
 
-export { syncTransformers, asyncTransformers, State }
+export { syncTransformers, asyncTransformers, State, prepareOptions }
 export { pathGetter, pathSetter } from './createPathMapper.js'
 
 export interface InitialState {
@@ -17,14 +21,31 @@ export interface InitialState {
   noDefaults?: boolean
 }
 
-// Prepare the pipelines that have their id in `neededPipelineIds` Set. Return
-// a Map of the pipelines.
-function preparePipelines(options: Options) {
-  const pipelines = new Map()
-  if (options.neededPipelineIds && options.pipelines) {
-    for (const id of options.neededPipelineIds) {
-      const pipeline = options.pipelines[id] // eslint-disable-line security/detect-object-injection
-      pipelines.set(id, preparePipeline(pipeline, options))
+// Prepare the pipelines that have had their id added to `neededPipelineIds`,
+// and set them on the `pipelines` Map. Pipelines that are already prepared are
+// left alone, so preparing the same options again is free, and preparing a
+// pipeline may mark more pipelines as needed -- as a `Set` yields values added
+// while we're iterating it, these are prepared too.
+function preparePipelines(
+  { neededPipelineIds, pipelines }: VariantBookKeeping,
+  options: Options,
+) {
+  for (const id of neededPipelineIds) {
+    if (pipelines.has(id) || !options.pipelines) {
+      continue
+    }
+
+    // Set an empty pipeline before we prepare, so that a transformer that runs
+    // map-transform with our options while we're preparing won't start
+    // preparing this pipeline again. We fill the very same array below, so
+    // anyone holding on to it still ends up with the prepared steps.
+    const pipeline: PreppedPipeline = []
+    pipelines.set(id, pipeline)
+    try {
+      pipeline.push(...preparePipeline(options.pipelines[id], options)) // eslint-disable-line security/detect-object-injection
+    } catch (error) {
+      pipelines.delete(id)
+      throw error
     }
   }
   return pipelines
@@ -52,27 +73,35 @@ function createTransformFunctionAsync(
 
 function preparePipelinesAndStateProps(
   def: TransformDefinition,
-  options: Options,
-  transformers: Record<string, Transformer | AsyncTransformer>,
+  rawOptions: Options,
+  variant: Variant,
 ): [PreppedPipeline, Partial<State>] {
-  const stateProps: Partial<State> = { nonvalues: options.nonvalues } // These props will be added to the state object
+  // Prepare the options, unless they are already prepared. Prepared options
+  // hold the transformers and the prepared pipelines for both variants, and
+  // are shared by every `mapTransform()` call they are given to.
+  const [preparedOptions, book] = prepareOptionsWithBookKeeping(rawOptions)
+  const variantBook = book[variant] // eslint-disable-line security/detect-object-injection
+  const { transformers, neededPipelineIds } = variantBook
 
-  // Set the `neededPipelineIds` Set and add the built-in transformers.
-  options = {
-    ...options,
-    neededPipelineIds: new Set(),
-    transformers: { ...transformers, ...options.transformers },
-  }
+  // Make our own copy of the options for this variant, and give it the same
+  // book-keeping, so that a transformer running map-transform with the options
+  // it is given will share our prepared pipelines.
+  const options = withBookKeeping(
+    { ...preparedOptions, transformers, neededPipelineIds },
+    book,
+  )
 
-  // Prepare the pipeline.
+  // Prepare the pipeline. Any `$apply` operation will add its pipeline id to
+  // `neededPipelineIds` while we do.
   const pipeline = preparePipeline(def, options)
 
-  // Prepare all pipelines that have had their id in set in `neededPipelineIds`
-  // during pipeline preparation, and add them to the `pipelines` Map on the
-  // state object.
-  stateProps.pipelines = preparePipelines(options)
+  // Prepare the pipelines that are needed but not prepared yet, and hand the
+  // Map of them to the state object.
+  const stateProps: Partial<State> = {
+    nonvalues: rawOptions.nonvalues,
+    pipelines: preparePipelines(variantBook, options),
+  }
 
-  // Return the pipeline and state props.
   return [pipeline, stateProps]
 }
 
@@ -91,7 +120,7 @@ export default function mapTransform(
   const [pipeline, stateProps] = preparePipelinesAndStateProps(
     def,
     options,
-    syncTransformers,
+    'sync',
   )
   return createTransformFunction(pipeline, stateProps)
 }
@@ -111,7 +140,7 @@ export function mapTransformAsync(
   const [pipeline, stateProps] = preparePipelinesAndStateProps(
     def,
     options,
-    asyncTransformers,
+    'async',
   )
   return createTransformFunctionAsync(pipeline, stateProps)
 }

--- a/src/prepareOptions.test.ts
+++ b/src/prepareOptions.test.ts
@@ -1,0 +1,89 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import type { Transformer } from './typesNext.js'
+
+import prepareOptions, { getBookKeeping } from './prepareOptions.js'
+
+// Setup
+
+const upperCase: Transformer = () => () => (value) =>
+  typeof value === 'string' ? value.toUpperCase() : value
+
+// Tests
+
+test('should return a copy of the options', () => {
+  const pipelines = { entry: ['title'] }
+  const options = { pipelines }
+
+  const ret = prepareOptions(options)
+
+  assert.notEqual(ret, options)
+  assert.equal(ret.pipelines, pipelines) // Passed on by reference
+})
+
+test('should not modify the options it is given', () => {
+  const options = { pipelines: { entry: ['title'] } }
+  const expected = { pipelines: { entry: ['title'] } }
+
+  prepareOptions(options)
+
+  assert.deepEqual(options, expected)
+  assert.equal(getBookKeeping(options), undefined)
+})
+
+test('should include the built-in transformers for both variants', () => {
+  const options = { transformers: { upperCase } }
+
+  const ret = prepareOptions(options)
+  const book = getBookKeeping(ret)
+
+  assert.equal(book?.sync.transformers.upperCase, upperCase)
+  assert.equal(book?.async.transformers.upperCase, upperCase)
+  assert.equal(typeof book?.sync.transformers.compare, 'function')
+  assert.equal(typeof book?.async.transformers.compare, 'function')
+  assert.notEqual(
+    book?.sync.transformers.compare,
+    book?.async.transformers.compare,
+  )
+})
+
+test('should let custom transformers override the built-in ones', () => {
+  const options = { transformers: { compare: upperCase } }
+
+  const ret = prepareOptions(options)
+  const book = getBookKeeping(ret)
+
+  assert.equal(book?.sync.transformers.compare, upperCase)
+  assert.equal(book?.async.transformers.compare, upperCase)
+})
+
+test('should give each variant its own pipelines map', () => {
+  const options = { pipelines: { entry: ['title'] } }
+
+  const ret = prepareOptions(options)
+  const book = getBookKeeping(ret)
+
+  assert.equal(book?.sync.pipelines.size, 0)
+  assert.equal(book?.async.pipelines.size, 0)
+  assert.notEqual(book?.sync.pipelines, book?.async.pipelines)
+})
+
+test('should return already prepared options as they are', () => {
+  const options = { pipelines: { entry: ['title'] } }
+  const prepared = prepareOptions(options)
+
+  const ret = prepareOptions(prepared)
+
+  assert.equal(ret, prepared)
+  assert.equal(getBookKeeping(ret), getBookKeeping(prepared))
+})
+
+test('should not expose the book-keeping as an enumerable prop', () => {
+  const options = { pipelines: { entry: ['title'] } }
+  const expected = ['pipelines']
+
+  const ret = prepareOptions(options)
+
+  assert.deepEqual(Object.keys(ret), expected)
+  assert.deepEqual(Object.getOwnPropertySymbols({ ...ret }), [])
+})

--- a/src/prepareOptions.ts
+++ b/src/prepareOptions.ts
@@ -1,0 +1,97 @@
+import {
+  sync as syncTransformers,
+  async as asyncTransformers,
+} from './transformers/index.js'
+import type { Options } from './prep/index.js'
+import type { PreppedPipeline } from './run/index.js'
+import type { Transformer, AsyncTransformer } from './typesNext.js'
+
+// Holds the book-keeping for an options object on a symbol key, so that it is
+// kept local to this module. Another copy of map-transform will prepare the
+// options again instead of trusting ours.
+const bookKeeping = Symbol('bookKeeping')
+
+export type Variant = 'sync' | 'async'
+
+// The transformers and the prepared pipelines for one of the two variants. A
+// pipeline is prepared with the transformers baked in, so the sync and the
+// async variant may never share prepared pipelines.
+export interface VariantBookKeeping {
+  transformers: Record<string | symbol, Transformer | AsyncTransformer>
+  neededPipelineIds: Set<string | symbol>
+  pipelines: Map<string | symbol, PreppedPipeline>
+}
+
+export type BookKeeping = Record<Variant, VariantBookKeeping>
+
+const createVariant = (
+  builtIns: Record<string, Transformer | AsyncTransformer>,
+  options: Options,
+): VariantBookKeeping => ({
+  transformers: { ...builtIns, ...options.transformers },
+  neededPipelineIds: new Set(),
+  pipelines: new Map(),
+})
+
+/**
+ * Return the book-keeping for the given options, or `undefined` when the
+ * options have not been prepared.
+ */
+export const getBookKeeping = (options: Options): BookKeeping | undefined =>
+  Reflect.get(options, bookKeeping)
+
+/**
+ * Set the given book-keeping on the given options object and return it. The
+ * book-keeping is not enumerable, so spreading prepared options loses it --
+ * everyone making an internal copy has to put it back, to keep sharing the
+ * prepared pipelines.
+ */
+export function withBookKeeping<T extends Options>(
+  options: T,
+  book: BookKeeping,
+): T {
+  Object.defineProperty(options, bookKeeping, {
+    value: book,
+    enumerable: false,
+  })
+  return options
+}
+
+/**
+ * Returns a completed options object, ready to be given to `mapTransform()`.
+ * The options object is shallow cloned, so we never modify the object we're
+ * given. `pipelines` and `dictionaries` are passed through by reference.
+ *
+ * Prepared options hold the pipelines that have been prepared from the
+ * `pipelines` object, so that every pipeline is prepared only once. Call this
+ * method up front and pass the returned options to several `mapTransform()`
+ * calls, to share prepared pipelines between them. This is opt-in, as pipelines
+ * are prepared with the transformers from the options they were prepared with,
+ * and may only be shared by transformations that agree on those options.
+ *
+ * The function is idempotent: options we have already prepared are returned
+ * as-is, so preparing them again -- or passing them to `mapTransform()` -- is
+ * free.
+ */
+export default function prepareOptions(options: Options): Options {
+  return prepareOptionsWithBookKeeping(options)[0]
+}
+
+/**
+ * As `prepareOptions()`, but returns the book-keeping along with the options,
+ * so that we don't have to look it up again. For internal use.
+ */
+export function prepareOptionsWithBookKeeping(
+  options: Options,
+): [Options, BookKeeping] {
+  const existing = getBookKeeping(options)
+  if (existing) {
+    return [options, existing]
+  }
+
+  const book: BookKeeping = {
+    sync: createVariant(syncTransformers, options),
+    async: createVariant(asyncTransformers, options),
+  }
+  return [withBookKeeping({ ...options }, book), book]
+}

--- a/src/tests/apply.test.ts
+++ b/src/tests/apply.test.ts
@@ -1,7 +1,12 @@
 import test from 'node:test'
 import assert from 'node:assert/strict'
 
-import mapTransformSync, { mapTransformAsync } from '../mapTransform.js'
+import mapTransformSync, {
+  mapTransformAsync,
+  prepareOptions,
+} from '../mapTransform.js'
+import { isObject } from '../utils/is.js'
+import type { Transformer } from '../typesNext.js'
 
 // Setup
 
@@ -525,4 +530,99 @@ test('should throw when applying an unknown pipeline inside a transform object',
   )
 
   assert.throws(() => mapTransformSync(def, options), expectedError)
+})
+
+test('should share prepared pipelines between calls given the same prepared options', () => {
+  let prepareCount = 0
+  const countPrepares: Transformer = () => () => {
+    prepareCount++
+    return (value: unknown) => value
+  }
+  const options = prepareOptions({
+    pipelines: { entry: [{ $transform: 'countPrepares' }, 'title'] },
+    transformers: { countPrepares },
+  })
+  const data = { title: 'Entry 1' }
+  const expectedFirst = { first: 'Entry 1' }
+  const expectedSecond = { second: 'Entry 1' }
+  const expectedPrepareCount = 1
+
+  const retFirst = mapTransformSync(
+    { first: { $apply: 'entry' } },
+    options,
+  )(data)
+  const retSecond = mapTransformSync(
+    { second: { $apply: 'entry' } },
+    options,
+  )(data)
+
+  assert.deepEqual(retFirst, expectedFirst)
+  assert.deepEqual(retSecond, expectedSecond)
+  assert.equal(prepareCount, expectedPrepareCount)
+})
+
+test('should not share prepared pipelines when options are not prepared up front', () => {
+  let prepareCount = 0
+  const countPrepares: Transformer = () => () => {
+    prepareCount++
+    return (value: unknown) => value
+  }
+  const options = {
+    pipelines: { entry: [{ $transform: 'countPrepares' }, 'title'] },
+    transformers: { countPrepares },
+  }
+  const data = { title: 'Entry 1' }
+  const expectedFirst = { first: 'Entry 1' }
+  const expectedSecond = { second: 'Entry 1' }
+  const expectedPrepareCount = 2
+
+  const retFirst = mapTransformSync(
+    { first: { $apply: 'entry' } },
+    options,
+  )(data)
+  const retSecond = mapTransformSync(
+    { second: { $apply: 'entry' } },
+    options,
+  )(data)
+
+  assert.deepEqual(retFirst, expectedFirst)
+  assert.deepEqual(retSecond, expectedSecond)
+  assert.equal(prepareCount, expectedPrepareCount)
+})
+
+test('should not share prepared pipelines between sync and async', async () => {
+  const options = prepareOptions({
+    pipelines: { entry: ['title', { $transform: 'dontTouchAsync' }] },
+    transformers,
+  })
+  const data = { title: 'Entry 1' }
+  const expected = { id: 'Entry 1' }
+
+  const ret = await mapTransformAsync(
+    { id: { $apply: 'entry' } },
+    options,
+  )(data)
+
+  assert.deepEqual(ret, expected)
+})
+
+test('should apply pipeline with a transformer that runs map-transform during preparation', () => {
+  const templateLike: Transformer = () => (options) => {
+    const inner = mapTransformSync({ $apply: 'wrapper' }, options)
+    return (value: unknown) =>
+      isObject(value) && value.expand ? inner(value) : value
+  }
+  const options = {
+    pipelines: {
+      entry: [{ $transform: 'templateLike' }, 'title'],
+      wrapper: [{ $apply: 'entry' }],
+    },
+    transformers: { templateLike },
+  }
+  const data = { title: 'Entry 1' }
+  const expected = { result: 'Entry 1' }
+
+  const ret = mapTransformSync({ result: { $apply: 'entry' } }, options)(data)
+
+  assert.deepEqual(ret, expected)
 })


### PR DESCRIPTION
`mapTransform()` built a fresh `Map` of prepared pipelines on every call, so N calls sharing an options object prepared the same pipelines N times. Legacy got a `prepareOptions()` for this; this is the `next` equivalent, done a bit differently.

### How it works

`prepareOptions(options)` returns a shallow copy carrying book-keeping on a non-enumerable symbol:

```js
const options = prepareOptions({ pipelines, transformers })
mapTransform(def1, options)   // prepares `entry`
mapTransform(def2, options)   // reuses it
```

Three decisions worth reviewing:

- **The cache lives on the options object**, not in a global keyed by pipeline id. A prepared pipeline has its transformers baked in, so two calls may only share one if they agree on the options that produced it. That's also why this is opt-in.
- **`mapTransform()` owns the Map, rather than copying out of it.** The state gets the shared Map directly and we only prepare the ids missing from it. Unused entries in the Map are harmless.
- **Sync and async get separate book-keeping** — different built-in transformers, so they can never share prepared pipelines. Legacy has no equivalent of this split.

Unprepared options behave exactly as before, they just don't share. `prepareOptions()` is idempotent and never touches the object it's given.

### Re-entrant preparation

Folded in, because it's the same machinery. A pipeline is now cached as an empty array *before* it's prepared, and that same array is then filled — so a transformer that runs map-transform during its own preparation finds the in-progress pipeline instead of preparing it again. This is legacy's placeholder trick (418ac3e), adapted: there the placeholder was a lazy operation, here it's the array identity.

Without this, a transformer that compiles a sub-definition at prepare time recursed until the stack blew, whenever that sub-definition reached back into the pipeline being prepared. Covered by `should apply pipeline with a transformer that runs map-transform during preparation`, which overflows the stack on `refactor`.

### Not included

`prep/apply.ts` still creates `neededPipelineIds` on the options object it's handed if it's missing. That branch is now unreachable: `mapTransform()` always supplies the Set, and the only other caller, `createDataMapper()`, is internal and always gets options that have been through here. Closing it properly means making the Set required in an internal options type — worth doing if `createDataMapper()` ever becomes public, but it would have doubled this diff for no behaviour change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)